### PR TITLE
[0.27.0] Model visibility update

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -34,7 +34,7 @@ dependencies {
 }
 
 group = "net.tickmc"
-version = "0.26.8-b" + buildNumber() + "-DEV"
+version = "0.27.0-b" + buildNumber() + "-DEV"
 description = "Megizen"
 java.sourceCompatibility = JavaVersion.VERSION_17
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,5 +2,5 @@ project.build.sourceEncoding=UTF-8
 craftbukkit.version=1.20.4-R0.1-SNAPSHOT
 citizens.version=2.0.33-SNAPSHOT
 denizen.version=1.3.0-SNAPSHOT
-modelengine.version=R4.0.6
+modelengine.version=R4.0.8
 BUILD_NUMBER=Unknown

--- a/src/main/java/net/tickmc/megizen/bukkit/commands/MegModelCommand.java
+++ b/src/main/java/net/tickmc/megizen/bukkit/commands/MegModelCommand.java
@@ -28,16 +28,15 @@ public class MegModelCommand extends AbstractCommand {
 
     // <--[command]
     // @Name MegModel
-    // @Syntax megmodel [model:<model>] (entity:<modeled_entity>) (dummy) (remove)
+    // @Syntax megmodel [model:<model>] [entity:<modeled_entity>] (remove)
     // @Required 2
-    // @Short Adds or removes a model from an entity, or creates a dummy entity with a model.
+    // @Short Adds or removes a model from an entity.
     // @Group Megizen
     //
     // @Description
-    // Adds or removes a model from an entity, or creates a dummy entity with a model.
+    // Adds or removes a model from an entity.
     // If the player disconnects, the model does not persist and the player becomes invisible. Use the 'meg_make_visible' mechanism to fix this.
     // Models do not persist across worlds. They should be removed first, then added back.
-    // Dummy entities require a modeled entity to not be specified, as it creates a new modeled entity.
     //
     // The model must be a name of a loaded model in ModelEngine.
     //
@@ -58,8 +57,7 @@ public class MegModelCommand extends AbstractCommand {
     }
 
     public static void autoExecute(ScriptEntry scriptEntry,
-                                   @ArgName("entity") @ArgPrefixed @ArgDefaultNull MegModeledEntityTag modeledEntityTag,
-                                   @ArgName("dummy") boolean dummy,
+                                   @ArgName("entity") @ArgPrefixed MegModeledEntityTag modeledEntityTag,
                                    @ArgName("model") @ArgPrefixed ElementTag model,
                                    @ArgName("remove") boolean remove) {
         ModelBlueprint blueprint = ModelEngineAPI.getBlueprint(model.asString());
@@ -68,21 +66,10 @@ public class MegModelCommand extends AbstractCommand {
             return;
         }
 
-        if (modeledEntityTag != null && dummy) {
-            Debug.echoError("Cannot specify a modeled entity and add the dummy flag at the same time.");
-            return;
-        }
-
         ModeledEntity modeledEntity = modeledEntityTag.getModeledEntity();
-        if (modeledEntity == null && !dummy) {
+        if (modeledEntity == null) {
             Debug.echoError("Invalid entity provided: " + modeledEntityTag.identify());
             return;
-        }
-
-        if (modeledEntity == null && dummy) {
-            Dummy<?> dummyEntity = new Dummy<>();
-            dummyEntity.setDetectingPlayers(false);
-            modeledEntity = ModelEngineAPI.createModeledEntity(dummyEntity);
         }
 
         Player player = Bukkit.getPlayer(modeledEntity.getBase().getUUID()) != null ? Bukkit.getPlayer(modeledEntity.getBase().getUUID()) : null;
@@ -114,7 +101,7 @@ public class MegModelCommand extends AbstractCommand {
                 modeledEntity.setBaseEntityVisible(false);
                 IEntityData iEntityData = modeledEntity.getBase().getData();
                 if (iEntityData instanceof BukkitEntityData data) {
-                    data.getTracked().addForcedPairing(player);
+                    data.getTracked().addForcedPairing(player.getUniqueId());
                 }
                 ModelEngineAPI.getEntityHandler().setForcedInvisible(player, true);
                 ActiveModel activeModel = ModelEngineAPI.createActiveModel(blueprint);

--- a/src/main/java/net/tickmc/megizen/bukkit/commands/MegModelCommand.java
+++ b/src/main/java/net/tickmc/megizen/bukkit/commands/MegModelCommand.java
@@ -57,7 +57,7 @@ public class MegModelCommand extends AbstractCommand {
     }
 
     public static void autoExecute(ScriptEntry scriptEntry,
-                                   @ArgName("entity") @ArgPrefixed MegModeledEntityTag modeledEntityTag,
+                                   @ArgName("entity") @ArgPrefixed @ArgDefaultNull MegModeledEntityTag modeledEntityTag,
                                    @ArgName("dummy") boolean dummy,
                                    @ArgName("model") @ArgPrefixed ElementTag model,
                                    @ArgName("remove") boolean remove) {

--- a/src/main/java/net/tickmc/megizen/bukkit/commands/MegModelCommand.java
+++ b/src/main/java/net/tickmc/megizen/bukkit/commands/MegModelCommand.java
@@ -3,6 +3,7 @@ package net.tickmc.megizen.bukkit.commands;
 import com.denizenscript.denizencore.objects.core.ElementTag;
 import com.denizenscript.denizencore.scripts.ScriptEntry;
 import com.denizenscript.denizencore.scripts.commands.AbstractCommand;
+import com.denizenscript.denizencore.scripts.commands.generator.ArgDefaultNull;
 import com.denizenscript.denizencore.scripts.commands.generator.ArgName;
 import com.denizenscript.denizencore.scripts.commands.generator.ArgPrefixed;
 import com.denizenscript.denizencore.utilities.debugging.Debug;

--- a/src/main/java/net/tickmc/megizen/bukkit/commands/MegModelCommand.java
+++ b/src/main/java/net/tickmc/megizen/bukkit/commands/MegModelCommand.java
@@ -68,14 +68,14 @@ public class MegModelCommand extends AbstractCommand {
             return;
         }
 
-        ModeledEntity modeledEntity = modeledEntityTag.getModeledEntity();
-        if (modeledEntity == null && !dummy) {
-            Debug.echoError("Invalid entity provided: " + modeledEntityTag.identify());
+        if (modeledEntityTag != null && dummy) {
+            Debug.echoError("Cannot specify a modeled entity and add the dummy flag at the same time.");
             return;
         }
 
-        if (modeledEntity != null && dummy) {
-            Debug.echoError("Cannot specify a modeled entity and add the dummy flag at the same time.");
+        ModeledEntity modeledEntity = modeledEntityTag.getModeledEntity();
+        if (modeledEntity == null && !dummy) {
+            Debug.echoError("Invalid entity provided: " + modeledEntityTag.identify());
             return;
         }
 

--- a/src/main/java/net/tickmc/megizen/bukkit/commands/MegModelCommand.java
+++ b/src/main/java/net/tickmc/megizen/bukkit/commands/MegModelCommand.java
@@ -3,12 +3,10 @@ package net.tickmc.megizen.bukkit.commands;
 import com.denizenscript.denizencore.objects.core.ElementTag;
 import com.denizenscript.denizencore.scripts.ScriptEntry;
 import com.denizenscript.denizencore.scripts.commands.AbstractCommand;
-import com.denizenscript.denizencore.scripts.commands.generator.ArgDefaultNull;
 import com.denizenscript.denizencore.scripts.commands.generator.ArgName;
 import com.denizenscript.denizencore.scripts.commands.generator.ArgPrefixed;
 import com.denizenscript.denizencore.utilities.debugging.Debug;
 import com.ticxo.modelengine.api.ModelEngineAPI;
-import com.ticxo.modelengine.api.entity.Dummy;
 import com.ticxo.modelengine.api.entity.data.BukkitEntityData;
 import com.ticxo.modelengine.api.entity.data.IEntityData;
 import com.ticxo.modelengine.api.generator.blueprint.ModelBlueprint;
@@ -22,7 +20,7 @@ public class MegModelCommand extends AbstractCommand {
 
     public MegModelCommand() {
         setName("megmodel");
-        setSyntax("megmodel [model:<model>] (entity:<modeled_entity>) (dummy) (remove)");
+        setSyntax("megmodel [model:<model>] [entity:<modeled_entity>] (remove)");
         autoCompile();
     }
 

--- a/src/main/java/net/tickmc/megizen/bukkit/commands/MegModelCommand.java
+++ b/src/main/java/net/tickmc/megizen/bukkit/commands/MegModelCommand.java
@@ -20,7 +20,7 @@ public class MegModelCommand extends AbstractCommand {
 
     public MegModelCommand() {
         setName("megmodel");
-        setSyntax("megmodel [model:<model>] [entity:<modeled_entity>] (remove)");
+        setSyntax("megmodel [entity:<modeled_entity>] [model:<model>] (remove)");
         autoCompile();
     }
 

--- a/src/main/java/net/tickmc/megizen/bukkit/commands/MegModelCommand.java
+++ b/src/main/java/net/tickmc/megizen/bukkit/commands/MegModelCommand.java
@@ -26,7 +26,7 @@ public class MegModelCommand extends AbstractCommand {
 
     // <--[command]
     // @Name MegModel
-    // @Syntax megmodel [model:<model>] [entity:<modeled_entity>] (remove)
+    // @Syntax megmodel [entity:<modeled_entity>] [model:<model>] (remove)
     // @Required 2
     // @Short Adds or removes a model from an entity.
     // @Group Megizen

--- a/src/main/java/net/tickmc/megizen/bukkit/objects/MegModeledEntityTag.java
+++ b/src/main/java/net/tickmc/megizen/bukkit/objects/MegModeledEntityTag.java
@@ -16,20 +16,15 @@ import com.denizenscript.denizencore.tags.ObjectTagProcessor;
 import com.denizenscript.denizencore.tags.TagContext;
 import com.denizenscript.denizencore.utilities.CoreUtilities;
 import com.denizenscript.denizencore.utilities.debugging.Debug;
-import com.denizenscript.denizencore.utilities.text.StringHolder;
 import com.ticxo.modelengine.api.ModelEngineAPI;
-import com.ticxo.modelengine.api.entity.BaseEntity;
-import com.ticxo.modelengine.api.entity.Dummy;
 import com.ticxo.modelengine.api.entity.data.BukkitEntityData;
 import com.ticxo.modelengine.api.entity.data.IEntityData;
 import com.ticxo.modelengine.api.model.ActiveModel;
 import com.ticxo.modelengine.api.model.ModeledEntity;
 import com.ticxo.modelengine.api.nms.entity.wrapper.TrackedEntity;
 import org.bukkit.entity.Entity;
-import org.bukkit.entity.Player;
 
 import java.util.Iterator;
-import java.util.Map;
 
 public class MegModeledEntityTag implements ObjectTag, Adjustable {
 
@@ -196,23 +191,6 @@ public class MegModeledEntityTag implements ObjectTag, Adjustable {
         });
 
         // <--[tag]
-        // @attribute <MegModeledEntityTag.visible_to>
-        // @returns ListTag(PlayerTag)
-        // @plugin Megizen
-        // @description
-        // Returns a list of players that can see the modeled entity.
-        // See also: <@link mechanism MegModeledEntityTag.hide_from>
-        // See also: <@link mechanism MegModeledEntityTag.show_to>
-        // -->
-        tagProcessor.registerTag(ListTag.class, "visible_to", (attribute, object) -> {
-            IEntityData entityData = object.modeledEntity.getBase().getData();
-            if (entityData instanceof BukkitEntityData bukkitData) {
-                return new ListTag(bukkitData.getTracked().getTrackedPlayer());
-            }
-            return null;
-        });
-
-        // <--[tag]
         // @attribute <MegModeledEntityTag.max_body_angle>
         // @returns ElementTag(Number)
         // @plugin Megizen
@@ -372,25 +350,21 @@ public class MegModeledEntityTag implements ObjectTag, Adjustable {
             return new ElementTag(object.getModeledEntity().getBase().getBodyRotationController().getStableAngle());
         });
 
-        // <--[mechanism]
-        // @object MegModeledEntityTag
-        // @name add_force_view
-        // @input PlayerTag
+        // <--[tag]
+        // @attribute <MegModeledEntityTag.visible_to>
+        // @returns ListTag(PlayerTag)
         // @plugin Megizen
         // @description
-        // Forces the modeled entity to only viewable by the input player.
-        // If the model was created without the 'dummy' flag, this will do nothing.
-        // Note: A forced viewer will be able to see the model forever, even when out of render radius.
-        // See also: <MegModeledEntityTag.hidden_from>
+        // Returns a list of players that can see the modeled entity.
+        // See also: <@link mechanism MegModeledEntityTag.hide_from>
+        // See also: <@link mechanism MegModeledEntityTag.show_to>
         // -->
-        tagProcessor.registerMechanism("force_view", false, PlayerTag.class, (object, mechanism, value) -> {
-            BaseEntity<?> baseEntity = object.modeledEntity.getBase();
-            if (baseEntity instanceof Dummy<?> dummy) {
-                dummy.setForceViewing(value.getPlayerEntity(), true);
+        tagProcessor.registerTag(ListTag.class, "visible_to", (attribute, object) -> {
+            IEntityData entityData = object.modeledEntity.getBase().getData();
+            if (entityData instanceof BukkitEntityData bukkitData) {
+                return new ListTag(bukkitData.getTracked().getTrackedPlayer());
             }
-            else {
-                Debug.echoError("Cannot force view with a non-dummy.");
-            }
+            return null;
         });
 
         // <--[mechanism]
@@ -422,35 +396,6 @@ public class MegModeledEntityTag implements ObjectTag, Adjustable {
         tagProcessor.registerMechanism("entity_visible", false, ElementTag.class, (object, mechanism, value) -> {
             boolean visible = value.asBoolean();
             object.modeledEntity.setBaseEntityVisible(visible);
-        });
-
-        // <--[mechanism]
-        // @object MegModeledEntityTag
-        // @name force_view
-        // @input MapTag
-        // @plugin Megizen
-        // @description
-        // Forces the modeled entity to either be viewable or not by the input player.
-        // If the model was created without the 'dummy' flag, this will do nothing.
-        // Note: A forced viewer will be able to see the model forever, even when out of render radius.
-        // See also: <MegModeledEntityTag.hidden_from>
-        // -->
-        tagProcessor.registerMechanism("force_view", false, MapTag.class, (object, mechanism, input) -> {
-            BaseEntity<?> baseEntity = object.modeledEntity.getBase();
-            if (baseEntity instanceof Dummy<?> dummy) {
-                for (Map.Entry<StringHolder, ObjectTag> entry : input.entrySet()) {
-                    PlayerTag player = PlayerTag.valueOf(entry.getKey().str, mechanism.context);
-                    if (player == null) {
-                        Debug.echoError("Invalid player provided: " + entry.getKey().str);
-                        continue;
-                    }
-                    boolean view = new ElementTag(entry.getValue().toString()).asBoolean();
-                    dummy.setForceViewing(player.getPlayerEntity(), view);
-                }
-            }
-            else {
-                Debug.echoError("Cannot force view with a non-dummy.");
-            }
         });
 
         // <--[mechanism]
@@ -558,27 +503,6 @@ public class MegModeledEntityTag implements ObjectTag, Adjustable {
 
         // <--[mechanism]
         // @object MegModeledEntityTag
-        // @name remove_force_view
-        // @input PlayerTag
-        // @plugin Megizen
-        // @description
-        // Removes the input player from the forced viewable list of the modeled entity.
-        // If the model was created without the 'dummy' flag, this will do nothing.
-        // Note: A forced viewer will be able to see the model forever, even when out of render radius.
-        // See also: <MegModeledEntityTag.hidden_from>
-        // -->
-        tagProcessor.registerMechanism("remove_force_view", false, PlayerTag.class, (object, mechanism, value) -> {
-            BaseEntity<?> baseEntity = object.modeledEntity.getBase();
-            if (baseEntity instanceof Dummy<?> dummy) {
-                dummy.setForceViewing(value.getPlayerEntity(), false);
-            }
-            else {
-                Debug.echoError("Cannot force view a non-dummy entity.");
-            }
-        });
-
-        // <--[mechanism]
-        // @object MegModeledEntityTag
         // @name rotation_delay
         // @input DurationTag
         // @plugin Megizen
@@ -641,23 +565,6 @@ public class MegModeledEntityTag implements ObjectTag, Adjustable {
 
         // <--[mechanism]
         // @object MegModeledEntityTag
-        // @name stable_angle
-        // @input ElementTag(Number)
-        // @plugin Megizen
-        // @description
-        // Sets the stable angle before correcting back to the clamped angle.
-        // For example, if the clamp is 50, and the stable angle is 15, the body can be 65 degrees away from the head before snapping back to 50 degrees away.
-        // This causes the "sudden jerk" effect on all entity body rotation.
-        // @tags
-        // <MegModeledEntityTag.stable_angle>
-        // -->
-        tagProcessor.registerMechanism("stable_angle", false, ElementTag.class, (object, mechanism, value) -> {
-            float angle = value.asFloat();
-            object.modeledEntity.getBase().getBodyRotationController().setStableAngle(angle);
-        });
-
-        // <--[mechanism]
-        // @object MegModeledEntityTag
         // @name show_to
         // @input PlayerTag
         // @plugin Megizen
@@ -675,6 +582,23 @@ public class MegModeledEntityTag implements ObjectTag, Adjustable {
                     entity.removeForcedHidden(value.getPlayerEntity().getUniqueId());
                 }
             }
+        });
+
+        // <--[mechanism]
+        // @object MegModeledEntityTag
+        // @name stable_angle
+        // @input ElementTag(Number)
+        // @plugin Megizen
+        // @description
+        // Sets the stable angle before correcting back to the clamped angle.
+        // For example, if the clamp is 50, and the stable angle is 15, the body can be 65 degrees away from the head before snapping back to 50 degrees away.
+        // This causes the "sudden jerk" effect on all entity body rotation.
+        // @tags
+        // <MegModeledEntityTag.stable_angle>
+        // -->
+        tagProcessor.registerMechanism("stable_angle", false, ElementTag.class, (object, mechanism, value) -> {
+            float angle = value.asFloat();
+            object.modeledEntity.getBase().getBodyRotationController().setStableAngle(angle);
         });
     }
 

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,6 +1,6 @@
 name: Megizen
 authors: ['The DenizenScript Team', '0TickPulse', 'heypr']
-version: 0.1.0-DEV (build ${BUILD_NUMBER})
+version: 0.27.0-DEV
 main: net.tickmc.megizen.bukkit.Megizen
 depend: [Denizen, ModelEngine]
 


### PR DESCRIPTION
- New `visible_to` tag, returns a ListTag(PlayerTag) of players who the model is visible to.
- New `hide_from` mech, allows you to hide the model from the input player(s).
- New `show_to` mech, allows you to show the model to the input player(s).
- Updated MEG API to 4.0.8.