### PR TITLE
Api and command fixes

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 project.build.sourceEncoding=UTF-8
 craftbukkit.version=1.20.4-R0.1-SNAPSHOT
 denizen.version=1.3.0-SNAPSHOT
-modelengine.version=R4.0.7
+modelengine.version=R4.0.8
 BUILD_NUMBER=Unknown

--- a/src/main/java/net/tickmc/megizen/bukkit/DenizenMountController.java
+++ b/src/main/java/net/tickmc/megizen/bukkit/DenizenMountController.java
@@ -1,0 +1,62 @@
+package net.tickmc.megizen.bukkit;
+
+import com.denizenscript.denizen.objects.EntityTag;
+import com.denizenscript.denizen.objects.LocationTag;
+import com.denizenscript.denizencore.objects.core.ElementTag;
+import com.denizenscript.denizencore.objects.core.ScriptTag;
+import com.denizenscript.denizencore.scripts.ScriptEntryData;
+import com.denizenscript.denizencore.scripts.queues.ScriptQueue;
+import com.denizenscript.denizencore.utilities.ScriptUtilities;
+import com.ticxo.modelengine.api.model.ActiveModel;
+import com.ticxo.modelengine.api.model.bone.type.Mount;
+import com.ticxo.modelengine.api.mount.controller.impl.AbstractMountController;
+import com.ticxo.modelengine.api.nms.entity.wrapper.MoveController;
+import net.tickmc.megizen.bukkit.objects.MegActiveModelTag;
+import org.bukkit.entity.Entity;
+
+import java.util.function.Consumer;
+
+
+public class DenizenMountController extends AbstractMountController {
+    public final ScriptTag script;
+    public final String path;
+    public final ScriptEntryData entryData;
+
+    public DenizenMountController(ScriptTag script, String path, ScriptEntryData entryData, Entity entity, Mount mount) {
+        super(entity, mount);
+        this.script = script;
+        this.path = path;
+        this.entryData = entryData;
+    }
+
+    private void sharedConfigurations(ScriptQueue queue, MoveController moveController, ActiveModel activeModel) {
+        queue.addDefinition("entity", new EntityTag(getEntity()));
+        queue.addDefinition("model", new MegActiveModelTag(activeModel));
+        queue.addDefinition("is_on_ground", new ElementTag(moveController.isOnGround()));
+        queue.addDefinition("is_in_water", new ElementTag(moveController.isInWater()));
+        queue.addDefinition("velocity", new LocationTag(moveController.getVelocity()));
+        queue.addDefinition("input_front", new ElementTag(getInput().getFront()));
+        queue.addDefinition("input_side", new ElementTag(getInput().getSide()));
+        queue.addDefinition("is_jump", new ElementTag(getInput().isJump()));
+        queue.addDefinition("is_sneak", new ElementTag(getInput().isSneak()));
+        queue.addDefinition("is_sprint", new ElementTag(getInput().isSprint()));
+    }
+
+    @Override
+    public void updateDriverMovement(MoveController moveController, ActiveModel activeModel) {
+        Consumer<ScriptQueue> configure = queue -> {
+            sharedConfigurations(queue, moveController, activeModel);
+            queue.addDefinition("mount_type", new ElementTag("driver"));
+        };
+        ScriptUtilities.createAndStartQueue(script.getContainer(), path, entryData, null, configure, null, null, null, null);
+    }
+
+    @Override
+    public void updatePassengerMovement(MoveController moveController, ActiveModel activeModel) {
+        Consumer<ScriptQueue> configure = queue -> {
+            sharedConfigurations(queue, moveController, activeModel);
+            queue.addDefinition("mount_type", new ElementTag("passenger"));
+        };
+        ScriptUtilities.createAndStartQueue(script.getContainer(), path, entryData, null, configure, null, null, null, null);
+    }
+}

--- a/src/main/java/net/tickmc/megizen/bukkit/commands/MegModelCommand.java
+++ b/src/main/java/net/tickmc/megizen/bukkit/commands/MegModelCommand.java
@@ -77,7 +77,11 @@ public class MegModelCommand extends AbstractCommand {
                     Debug.echoError("Entity does not have model: " + model.asString());
                     return;
                 }
-                modeledEntity.removeModel(model.asString());
+                modeledEntity.removeModel(model.asString()).ifPresent(ActiveModel::destroy);
+                if (modeledEntity.getModels().isEmpty()) {
+                    modeledEntity.setBaseEntityVisible(true);
+                    ModelEngineAPI.removeModeledEntity(modeledEntity.getBase().getUUID());
+                }
             }
             else {
                 ActiveModel activeModel = ModelEngineAPI.createActiveModel(blueprint);
@@ -99,7 +103,7 @@ public class MegModelCommand extends AbstractCommand {
                 modeledEntity.setBaseEntityVisible(false);
                 IEntityData iEntityData = modeledEntity.getBase().getData();
                 if (iEntityData instanceof BukkitEntityData data) {
-                    data.getTracked().addForcedPairing(player);
+                    data.getTracked().addForcedPairing(player.getUniqueId());
                 }
                 ModelEngineAPI.getEntityHandler().setForcedInvisible(player, true);
                 ActiveModel activeModel = ModelEngineAPI.createActiveModel(blueprint);

--- a/src/main/java/net/tickmc/megizen/bukkit/commands/MegMountCommand.java
+++ b/src/main/java/net/tickmc/megizen/bukkit/commands/MegMountCommand.java
@@ -24,7 +24,7 @@ public class MegMountCommand extends AbstractCommand {
 
     public MegMountCommand() {
         setName("megmount");
-        setSyntax("megmount [entity:<entity>] [model:<active_model>] [bones:<bone>|...] [mode:driver/passenger/dismount] (force) (interactable) (damageable) (auto_dismount)");
+        setSyntax("megmount [entity:<entity>] [model:<active_model>] [type:driver/passenger] (bones:<bone>|...) (dismount) (force) (interactable) (damageable) (auto_dismount) (controller_type:{walking}/flying/walking_force/flying_force) (controller_script:<script>)");
         addRemappedPrefixes("bones", "bone");
         autoCompile();
     }

--- a/src/main/java/net/tickmc/megizen/bukkit/commands/MegMountCommand.java
+++ b/src/main/java/net/tickmc/megizen/bukkit/commands/MegMountCommand.java
@@ -1,48 +1,79 @@
 package net.tickmc.megizen.bukkit.commands;
 
 import com.denizenscript.denizen.objects.EntityTag;
+import com.denizenscript.denizencore.objects.core.ElementTag;
+import com.denizenscript.denizencore.objects.core.ScriptTag;
 import com.denizenscript.denizencore.scripts.ScriptEntry;
 import com.denizenscript.denizencore.scripts.commands.AbstractCommand;
-import com.denizenscript.denizencore.scripts.commands.generator.ArgDefaultNull;
-import com.denizenscript.denizencore.scripts.commands.generator.ArgName;
-import com.denizenscript.denizencore.scripts.commands.generator.ArgPrefixed;
+import com.denizenscript.denizencore.scripts.commands.BracedCommand;
+import com.denizenscript.denizencore.scripts.commands.generator.*;
+import com.denizenscript.denizencore.scripts.queues.ScriptQueue;
 import com.denizenscript.denizencore.utilities.debugging.Debug;
+import com.ticxo.modelengine.api.ModelEngineAPI;
 import com.ticxo.modelengine.api.model.ActiveModel;
+import com.ticxo.modelengine.api.model.bone.manager.MountManager;
+import com.ticxo.modelengine.api.mount.controller.MountControllerSupplier;
+import com.ticxo.modelengine.api.mount.controller.MountControllerType;
 import com.ticxo.modelengine.api.mount.controller.MountControllerTypes;
+import net.tickmc.megizen.bukkit.DenizenMountController;
 import net.tickmc.megizen.bukkit.objects.MegActiveModelTag;
+
+import java.util.List;
 
 public class MegMountCommand extends AbstractCommand {
 
     public MegMountCommand() {
         setName("megmount");
-        setSyntax("megmount [entity:<entity>] [model:<active_model>] [bone:<bone>] (driver) (passenger) (dismount) (interactable) (damageable)");
+        setSyntax("megmount [entity:<entity>] [model:<active_model>] [bones:<bone>|...] [mode:driver/passenger/dismount] (force) (interactable) (damageable) (auto_dismount)");
+        addRemappedPrefixes("bones", "bone");
         autoCompile();
+    }
+
+    public enum MountMode {
+        DRIVER,
+        PASSENGER,
+    }
+
+    public enum MountControllerTypeEnum {
+        WALKING,
+        FLYING,
+        WALKING_FORCE,
+        FLYING_FORCE,
     }
 
     // <--[command]
     // @Name MegMount
-    // @Syntax megmount [entity:<entity>] [model:<active_model>] [bone:<bone>] (driver) (passenger) (dismount) (interactable) (damageable)
+    // @Syntax megmount [entity:<entity>] [model:<active_model>] [type:driver/passenger] (bones:<bone>|...) (dismount) (force) (interactable) (damageable) (auto_dismount) (controller_type:{walking}/flying/walking_force/flying_force) (controller_script:<script>)
     // @Required 3
     // @Short Mounts the given entity on the given modeled entity, either as a passenger or the driver.
     // @Group Megizen
     //
     // @Description
     // Mounts the given entity on the given modeled entity, either as a passenger or the driver.
-    // The "bone_name" argument is required if the entity is being mounted as a passenger. It specifies which bone the entity will be mounted on.
+    // The "bones" argument is required if the entity is being mounted as a passenger. It specifies which bones the entity will be mounted on.
+    // If "force" is true, it selects the least occupied bone to mount the entity on. Otherwise, it will select the first bone that is not occupied.
     // You can find out mountable bone names by opening the model in Blockbench.
     // The "dismount" argument is optional, but will dismount the entity if specified.
     // The "interactable" and "damageable" arguments are optional, but make the mount interactable and damageable, respectively.
+    // If the command is used on an entity already mounted, it will do nothing if "auto_dismount" is not specified. Otherwise, it will dismount the entity first.
     // -->
 
     public static void autoExecute(ScriptEntry scriptEntry,
                                    @ArgName("entity") @ArgPrefixed EntityTag entity,
                                    @ArgName("model") @ArgPrefixed MegActiveModelTag model,
-                                   @ArgName("driver") @ArgDefaultNull boolean driver,
-                                   @ArgName("passenger") @ArgDefaultNull boolean passenger,
-                                   @ArgName("bone") @ArgPrefixed @ArgDefaultNull String boneName,
+                                   @ArgName("type") @ArgDefaultText("driver") MountMode type,
+                                   @ArgName("bones") @ArgSubType(ElementTag.class) @ArgPrefixed @ArgDefaultText("") List<ElementTag> bones,
                                    @ArgName("dismount") boolean dismount,
+                                   @ArgName("force") boolean force,
+                                   @ArgName("interactable") boolean interactable,
                                    @ArgName("damageable") boolean damageable,
-                                   @ArgName("interactable") boolean interactable) {
+                                   @ArgName("auto_dismount") boolean autoDismount,
+                                   @ArgName("controller_type") @ArgPrefixed @ArgDefaultText("walking") MountControllerTypeEnum controllerType,
+                                   @ArgName("controller_script") @ArgPrefixed @ArgDefaultNull ScriptTag controllerScript,
+
+                                   // for backwards compatibility
+                                   @ArgName("driver") boolean driver,
+                                   @ArgName("passenger") boolean passenger) {
         if (entity == null) {
             Debug.echoError("The 'entity' argument is required to mount an entity.");
             return;
@@ -51,46 +82,98 @@ public class MegMountCommand extends AbstractCommand {
             Debug.echoError("The 'model' argument is required to mount an entity.");
             return;
         }
-        if (!driver && !passenger) {
-            Debug.echoError("A type of 'driver' or 'passenger' must be specified.");
-            return;
-        }
+
+        // Backwards compatibility
         if (driver && passenger) {
-            Debug.echoError("Only one of 'driver' or 'passenger' can be specified.");
+            Debug.echoError("The 'driver' and 'passenger' arguments are mutually exclusive.");
             return;
         }
-        ActiveModel activeModel = model.getActiveModel();
-        if (driver && !dismount) {
-            activeModel.getMountManager().ifPresent(mountManager -> {
-                if (mountManager.getDriver() != null) {
-                    mountManager.dismountDriver();
-                }
-                mountManager.setCanDrive(true);
-                mountManager.setCanRide(true);
-                mountManager.mountDriver(entity.entity, MountControllerTypes.WALKING, mountController -> {
-                    mountController.setCanDamageMount(damageable);
-                    mountController.setCanInteractMount(interactable);
-                });
-            });
-        }
-        if (passenger && boneName.isEmpty() && !dismount) {
-            Debug.echoError("The 'bone' argument is required to mount an entity as a passenger.");
-            return;
+        if (driver) {
+            type = MountMode.DRIVER;
         }
         if (passenger) {
-            activeModel.getMountManager().ifPresent(mountManager -> {
-                mountManager.setCanDrive(true);
-                mountManager.setCanRide(true);
-                mountManager.mountPassenger(boneName, entity.entity, MountControllerTypes.WALKING, mountController -> {
-                    mountController.setCanDamageMount(damageable);
-                    mountController.setCanInteractMount(interactable);
-                });
-            });
+            type = MountMode.PASSENGER;
         }
-        if (dismount) {
-            activeModel.getMountManager().ifPresent(mountManager -> {
-                mountManager.dismountRider(entity.entity);
-            });
+
+        ActiveModel activeModel = model.getActiveModel();
+        List<String> boneNames = bones.stream().map(ElementTag::asString).toList();
+        MountControllerSupplier mountControllerType;
+        if (controllerScript == null) {
+            mountControllerType = switch (controllerType) {
+                case WALKING -> MountControllerTypes.WALKING;
+                case FLYING -> MountControllerTypes.FLYING;
+                case WALKING_FORCE -> MountControllerTypes.WALKING_FORCE;
+                case FLYING_FORCE -> MountControllerTypes.FLYING_FORCE;
+            };
+        } else {
+            mountControllerType = (entity1, mount) -> new DenizenMountController(controllerScript, null, scriptEntry.entryData, entity1, mount);
+        }
+
+        if (!dismount) {
+            ActiveModel mountedPair = ModelEngineAPI.getMountPairManager().getMountedPair(entity.getUUID());
+            if (mountedPair != null) {
+                if (!autoDismount) {
+                    return;
+                }
+                mountedPair.getMountManager().ifPresent(mountManager -> {
+                    mountManager.dismountRider(entity.entity);
+                });
+            }
+        }
+        switch (type) {
+            case DRIVER -> {
+                if (dismount) {
+                    activeModel.getMountManager().ifPresent(MountManager::dismountDriver);
+                    return;
+                }
+                activeModel.getMountManager().ifPresent(mountManager -> {
+                    if (mountManager.getDriver() != null) {
+                        mountManager.dismountDriver();
+                    }
+                    mountManager.setCanDrive(true);
+                    mountManager.setCanRide(true);
+                    mountManager.mountDriver(entity.entity, mountControllerType, mountController -> {
+                        mountController.setCanDamageMount(damageable);
+                        mountController.setCanInteractMount(interactable);
+                    });
+                });
+            }
+            case PASSENGER -> {
+                if (dismount) {
+                    activeModel.getMountManager().ifPresent(mountManager -> {
+                        if (boneNames.isEmpty()) {
+                            mountManager.dismountRider(entity.entity);
+                            return;
+                        }
+                        mountManager.getMount(entity.entity).ifPresent(mountController -> {
+                            if (boneNames.contains(mountController.getBone().getUniqueBoneId())) {
+                                mountManager.dismountRider(entity.entity);
+                            }
+                        });
+                    });
+                    return;
+                }
+                if (boneNames.isEmpty()) {
+                    Debug.echoError("The 'bone' argument is required to mount an entity as a passenger.");
+                    return;
+                }
+
+                activeModel.getMountManager().ifPresent(mountManager -> {
+                    mountManager.setCanDrive(true);
+                    mountManager.setCanRide(true);
+                    if (force) {
+                        mountManager.mountLeastOccupied(entity.entity, boneNames, mountControllerType, mountController -> {
+                            mountController.setCanDamageMount(damageable);
+                            mountController.setCanInteractMount(interactable);
+                        });
+                    } else {
+                        mountManager.mountAvailable(entity.entity, boneNames, mountControllerType, mountController -> {
+                            mountController.setCanDamageMount(damageable);
+                            mountController.setCanInteractMount(interactable);
+                        });
+                    }
+                });
+            }
         }
     }
 }

--- a/src/main/java/net/tickmc/megizen/bukkit/commands/MegStateCommand.java
+++ b/src/main/java/net/tickmc/megizen/bukkit/commands/MegStateCommand.java
@@ -19,13 +19,13 @@ import net.tickmc.megizen.bukkit.objects.MegActiveModelTag;
 public class MegStateCommand extends AbstractCommand {
     public MegStateCommand() {
         setName("megstate");
-        setSyntax("megstate [model:<active_model>] [state:<state>] (priority:<#>/{1}) ((speed:<#.#>/{1}) (lerp_in:<duration>/{0}) (lerp_out:<duration>/{0}) (loop:once/loop/hold) (override:true/false) (force)/remove (ignore_lerp))");
+        setSyntax("megstate [model:<active_model>] [state:<state>] (priority:<#>/{1}) ((speed:<#.#>/{1}) (lerp_in:<duration>/{0}) (lerp_out:<duration>/{0}) (loop:{once}/loop/hold) (override:true/false) (force)/remove (ignore_lerp))");
         autoCompile();
     }
 
     // <--[command]
     // @Name MegState
-    // @Syntax megstate [model:<active_model>] [state:<state>] (priority:<#>/{1}) ((speed:<#.#>/{1}) (lerp_in:<duration>/{0}) (lerp_out:<duration>/{0}) (loop:once/loop/hold) (override:true/false) (force)/remove (ignore_lerp))
+    // @Syntax megstate [model:<active_model>] [state:<state>] (priority:<#>/{1}) ((speed:<#.#>/{1}) (lerp_in:<duration>/{0}) (lerp_out:<duration>/{0}) (loop:{once}/loop/hold) (override:true/false) (force)/remove (ignore_lerp))
     // @Required 3
     // @Short Plays a state on a modeled entity.
     // @Group Megizen

--- a/src/main/java/net/tickmc/megizen/bukkit/commands/MegStateCommand.java
+++ b/src/main/java/net/tickmc/megizen/bukkit/commands/MegStateCommand.java
@@ -19,7 +19,7 @@ import net.tickmc.megizen.bukkit.objects.MegActiveModelTag;
 public class MegStateCommand extends AbstractCommand {
     public MegStateCommand() {
         setName("megstate");
-        setSyntax("megstate [model:<active_model>] [state:<state>] (priority:<#>/{1}) ((speed:<#.#>/{1}) (lerp_in:<duration>/{0}) (lerp_out:<duration>/{0}) (loop:{once}/loop/hold) (override:true/false) (force)/remove (ignore_lerp))");
+        setSyntax("megstate [model:<active_model>] [state:<state>] (priority:<#>/{1}) ((speed:<#.#>/{1}) (lerp_in:<duration>/{0}) (lerp_out:<duration>/{0}) (loop:once/loop/hold) (override:true/false) (force)/remove (ignore_lerp))");
         autoCompile();
     }
 
@@ -44,7 +44,7 @@ public class MegStateCommand extends AbstractCommand {
                                    @ArgName("speed") @ArgPrefixed @ArgDefaultText("1") float speed,
                                    @ArgName("lerp_in") @ArgPrefixed @ArgDefaultText("0") DurationTag lerpIn,
                                    @ArgName("lerp_out") @ArgPrefixed @ArgDefaultText("0") DurationTag lerpOut,
-                                   @ArgName("loop") @ArgPrefixed @ArgDefaultText("once") BlueprintAnimation.LoopMode loop,
+                                   @ArgName("loop") @ArgPrefixed @ArgDefaultNull BlueprintAnimation.LoopMode loop,
                                    @ArgName("override") @ArgPrefixed @ArgDefaultNull ElementTag override,
                                    @ArgName("force") @ArgDefaultText("true") boolean force,
                                    @ArgName("remove") @ArgDefaultText("false") boolean remove,
@@ -81,7 +81,9 @@ public class MegStateCommand extends AbstractCommand {
             ? smh.playAnimation(priority, state, lerpIn.getTicks(), lerpOut.getTicks(), speed, force)
             : handler.playAnimation(state, lerpIn.getTicks(), lerpOut.getTicks(), speed, force);
         if (property != null) {
-            property.setForceLoopMode(loop);
+            if (loop != null) {
+                property.setForceLoopMode(loop);
+            }
             if (override != null && override.isBoolean()) {
                 property.setForceOverride(override.asBoolean());
             }

--- a/src/main/java/net/tickmc/megizen/bukkit/events/ModelDismountScriptEvent.java
+++ b/src/main/java/net/tickmc/megizen/bukkit/events/ModelDismountScriptEvent.java
@@ -2,8 +2,10 @@ package net.tickmc.megizen.bukkit.events;
 
 import com.denizenscript.denizen.events.BukkitScriptEvent;
 import com.denizenscript.denizen.objects.EntityTag;
+import com.denizenscript.denizen.utilities.implementation.BukkitScriptEntryData;
 import com.denizenscript.denizencore.objects.ObjectTag;
 import com.denizenscript.denizencore.objects.core.ElementTag;
+import com.denizenscript.denizencore.scripts.ScriptEntryData;
 import com.ticxo.modelengine.api.events.ModelDismountEvent;
 import net.tickmc.megizen.bukkit.objects.MegActiveModelTag;
 import org.bukkit.event.EventHandler;
@@ -45,6 +47,11 @@ public class ModelDismountScriptEvent extends BukkitScriptEvent implements Liste
             return false;
         }
         return super.matches(path);
+    }
+
+    @Override
+    public ScriptEntryData getScriptEntryData() {
+        return new BukkitScriptEntryData(entity);
     }
 
     @Override

--- a/src/main/java/net/tickmc/megizen/bukkit/objects/MegActiveModelTag.java
+++ b/src/main/java/net/tickmc/megizen/bukkit/objects/MegActiveModelTag.java
@@ -146,27 +146,6 @@ public class MegActiveModelTag implements ObjectTag, Adjustable {
     public static void registerTags() {
 
         // <--[tag]
-        // @attribute <MegActiveModelTag.active_states>
-        // @returns
-        // @plugin Megizen
-        // @description
-        // -->
-        tagProcessor.registerTag(ListTag.class, "active_states", (attribute, object) -> {
-            AnimationHandler handler = object.getActiveModel().getAnimationHandler();
-            if (handler == null) {
-                return null;
-            }
-            ListTag list = new ListTag();
-            handler.getAnimations().forEach((animation, property) -> {
-                if (handler.isPlayingAnimation(animation)) {
-                    list.addObject(new ElementTag(animation));
-                }
-            });
-            return list;
-        });
-
-
-        // <--[tag]
         // @attribute <MegActiveModelTag.bone[<id>]>
         // @returns MegBoneTag
         // @plugin Megizen

--- a/src/main/java/net/tickmc/megizen/bukkit/objects/MegActiveModelTag.java
+++ b/src/main/java/net/tickmc/megizen/bukkit/objects/MegActiveModelTag.java
@@ -12,6 +12,7 @@ import com.denizenscript.denizencore.tags.ObjectTagProcessor;
 import com.denizenscript.denizencore.tags.TagContext;
 import com.denizenscript.denizencore.utilities.debugging.Debug;
 import com.ticxo.modelengine.api.ModelEngineAPI;
+import com.ticxo.modelengine.api.animation.handler.AnimationHandler;
 import com.ticxo.modelengine.api.model.ActiveModel;
 import com.ticxo.modelengine.api.model.ModeledEntity;
 import com.ticxo.modelengine.api.model.bone.ModelBone;
@@ -143,6 +144,27 @@ public class MegActiveModelTag implements ObjectTag, Adjustable {
     public static ObjectTagProcessor<MegActiveModelTag> tagProcessor = new ObjectTagProcessor<>();
 
     public static void registerTags() {
+
+        // <--[tag]
+        // @attribute <MegActiveModelTag.active_states>
+        // @returns
+        // @plugin Megizen
+        // @description
+        // -->
+        tagProcessor.registerTag(ListTag.class, "active_states", (attribute, object) -> {
+            AnimationHandler handler = object.getActiveModel().getAnimationHandler();
+            if (handler == null) {
+                return null;
+            }
+            ListTag list = new ListTag();
+            handler.getAnimations().forEach((animation, property) -> {
+                if (handler.isPlayingAnimation(animation)) {
+                    list.addObject(new ElementTag(animation));
+                }
+            });
+            return list;
+        });
+
 
         // <--[tag]
         // @attribute <MegActiveModelTag.bone[<id>]>

--- a/src/main/java/net/tickmc/megizen/bukkit/objects/MegModeledEntityTag.java
+++ b/src/main/java/net/tickmc/megizen/bukkit/objects/MegModeledEntityTag.java
@@ -430,8 +430,8 @@ public class MegModeledEntityTag implements ObjectTag, Adjustable {
             if (entityData instanceof BukkitEntityData bukkitData) {
                 TrackedEntity entity = bukkitData.getTracked();
                 for (PlayerTag player : value.filter(PlayerTag.class, mechanism.context)) {
-                    if (entity.getTrackedPlayer().contains(player.getPlayerEntity())) {
-                        entity.addForcedHidden(player.getPlayerEntity());
+                    if (entity.getTrackedPlayer().contains(player.getUUID())) {
+                        entity.addForcedHidden(player.getUUID());
                     }
                 }
             }
@@ -578,8 +578,8 @@ public class MegModeledEntityTag implements ObjectTag, Adjustable {
             IEntityData entityData = object.modeledEntity.getBase().getData();
             if (entityData instanceof BukkitEntityData bukkitData) {
                 TrackedEntity entity = bukkitData.getTracked();
-                if (entity.getTrackedPlayer().contains(value.getPlayerEntity())) {
-                    entity.removeForcedHidden(value.getPlayerEntity());
+                if (entity.getTrackedPlayer().contains(value.getUUID())) {
+                    entity.removeForcedHidden(value.getUUID());
                 }
             }
         });

--- a/src/main/java/net/tickmc/megizen/bukkit/properties/MegizenEntityTagExtensions.java
+++ b/src/main/java/net/tickmc/megizen/bukkit/properties/MegizenEntityTagExtensions.java
@@ -3,6 +3,7 @@ package net.tickmc.megizen.bukkit.properties;
 import com.denizenscript.denizen.objects.EntityTag;
 import com.ticxo.modelengine.api.ModelEngineAPI;
 import com.ticxo.modelengine.api.model.bone.behavior.BoneBehavior;
+import com.ticxo.modelengine.api.mount.controller.MountController;
 import net.tickmc.megizen.bukkit.objects.MegBoneTag;
 import net.tickmc.megizen.bukkit.objects.MegModeledEntityTag;
 
@@ -32,10 +33,14 @@ public class MegizenEntityTagExtensions {
         // Returns the MegBoneTag that the entity is mounted on, if any.
         // -->
         EntityTag.tagProcessor.registerTag(MegBoneTag.class, "mounted_bone", (attribute, entity) -> {
-            if (ModelEngineAPI.getMountPairManager().getController(entity.getUUID()).getMount() == null) {
+            MountController controller = ModelEngineAPI.getMountPairManager().getController(entity.getUUID());
+            if (controller == null) {
                 return null;
             }
-            return new MegBoneTag(((BoneBehavior) ModelEngineAPI.getMountPairManager().getController(entity.getUUID()).getMount()).getBone());
+            if (controller.getMount() == null) {
+                return null;
+            }
+            return new MegBoneTag(((BoneBehavior) controller.getMount()).getBone());
         });
     }
 }


### PR DESCRIPTION
## Changes

ModelEngine API dependency has been updated from `4.0.7` to `4.0.8`.

Megmount rework—new syntax: `megmount [entity:<entity>] [model:<active_model>] [type:driver/passenger] (bones:<bone>|...) (dismount) (force) (interactable) (damageable) (auto_dismount) (controller_type:{walking}/flying/walking_force/flying_force) (controller_script:<script>)`. Notable changes in the syntax include:

- `driver` and `passenger` are now in one argument `mode`. (The old arguments are still supported although not documented)
- `bone` is now `bones` (although the old one still works and is again not documented) and accepts a list of bones. If `force` is true, then it selects the least occupied bone. Otherwise, it selects the first available bone.
- New `auto_dismount` boolean argument for automatically dismounting a passenger before mounting a bone.
- New `controller_type` argument for changing the type of the controller.
- New `controller_script` argument for a custom Denizen task script as the controller. It runs every tick that the entity is mounted, and the script has the following definitions:
    - `<[entity]>` (EntityTag)—the entity that is mounting the model.
    - `<[model]>` (MegActiveModelTag)—the model that the entity is riding on.
    - `<[is_on_ground]>` (ElementTag(Boolean))
    - `<[is_in_water]>` (ElementTag(Boolean))
    - `<[velocity]>` (LocationTag)—the controller's velocity as a vector
    - `<[input_front]>`(ElementTag(Decimal))—`1` if pressing `w`, `-1` if pressing `s`, `0` otherwise.
    - `<[input_side]>` (ElementTag(Decimal))—`1` if pressing `a`, `-1` if pressing `d`, `0` otherwise.
    - `<[is_jump]>` (ElementTag(Boolean))—`true` if the jump key (usually spacebar) is pressed.
    - `<[is_sneak]>` (ElementTag(Boolean))—`true` if the sneak key (usually shift) is pressed.
    - `<[is_sprint]>` (ElementTag(Boolean))—`true` if the sprint key (usually left ctrl) is pressed.
    - `<[mount_type]>` (ElementTag)—returns either `driver` or `passenger`.

## Fixes

Fixed `megmodel` with `remove` not deleting the unused model after it detaches from the entity.

Fixed `megstate`'s `loop` argument being `once` by default. (Now it doesn't set it and lets MEG do its own logic with the BlockBench model)

Fixed NPE with `<EntityTag.mounted_bone>`

## Deprecations

- Old `megmount` arguments: `driver`, `passenger`, `bone`.